### PR TITLE
Properly delete allocated arrays

### DIFF
--- a/src/vmxcodec.cpp
+++ b/src/vmxcodec.cpp
@@ -128,14 +128,14 @@ VMX_API void VMX_Destroy(VMX_INSTANCE* instance)
 					delete instance->Slices[i];
 				}
 			}
-			delete instance->Slices;
+			delete[] instance->Slices;
 		}
 		for (int p = 0; p < VMX_QUALITY_COUNT; p++)
 		{
-			delete instance->EncodeQualityPresets[p];
-			delete instance->DecodeQualityPresets[p];
-			delete instance->EncodeQualityPresets256[p];
-			delete instance->DecodeQualityPresets256[p];
+			delete[] instance->EncodeQualityPresets[p];
+			delete[] instance->DecodeQualityPresets[p];
+			delete[] instance->EncodeQualityPresets256[p];
+			delete[] instance->DecodeQualityPresets256[p];
 		}
 		delete instance;
 	}


### PR DESCRIPTION
Stumbled across these during a valgrind session. These are actually arrays that need to be delete with the `delete[]` operator.