### PR TITLE
Fix out-of-bounds write and chroma corruption in P216/PA16 decode when width isn't a multiple of 32

### DIFF
--- a/src/vmxcodec_arm.cpp
+++ b/src/vmxcodec_arm.cpp
@@ -2161,14 +2161,14 @@ void VMX_PlanarToP216(BYTE* ysrc, int ystride, BYTE* usrc, int ustride, BYTE* vs
 			__m128i uv1 = _mm_unpacklo_epi16(u, v);
 			__m128i uv2 = _mm_unpackhi_epi16(u, v);
 
-			_mm_storeu_si128((__m128i*) & dstUV[x], uv1);
-			_mm_storeu_si128((__m128i*) & dstUV[x + 16], uv2);
+			_mm_storeu_si128((__m128i*) & pDst[x], uv1);
+			_mm_storeu_si128((__m128i*) & pDst[x + 16], uv2);
 			pU += 16;
 			pV += 16;
 		}
 		usrc += ustride;
 		vsrc += vstride;
-		dstUV += alignedStride;
+		pDst += alignedStride;
 		pU = usrc;
 		pV = vsrc;
 	}

--- a/src/vmxcodec_x86.cpp
+++ b/src/vmxcodec_x86.cpp
@@ -2167,14 +2167,14 @@ void VMX_PlanarToP216(BYTE* ysrc, int ystride, BYTE* usrc, int ustride, BYTE* vs
 			__m128i uv1 = _mm_unpacklo_epi16(u, v);
 			__m128i uv2 = _mm_unpackhi_epi16(u, v);
 
-			_mm_storeu_si128((__m128i*) & dstUV[x], uv1);
-			_mm_storeu_si128((__m128i*) & dstUV[x + 16], uv2);
+			_mm_storeu_si128((__m128i*) & pDst[x], uv1);
+			_mm_storeu_si128((__m128i*) & pDst[x + 16], uv2);
 			pU += 16;
 			pV += 16;
 		}
 		usrc += ustride;
 		vsrc += vstride;
-		dstUV += alignedStride;
+		pDst += alignedStride;
 		pU = usrc;
 		pV = vsrc;
 	}


### PR DESCRIPTION
`VMX_PlanarToP216` sets up the aligned scratch buffer and assigns `pDst` to it, but the store loop writes to `dstUV` and advances `dstUV` by `alignedStride`. So the UV samples land in the caller's buffer at the scratch pitch, and the `CopyFromAlignedStrideBufferAndFree` at the end copies the scratch buffer (which was never written) to a pointer that has already walked off the end of the plane.

It only bites when the scratch path is actually active, i.e. width % 32 != 0. 1920, 1280, 2560, 3840 are all fine, which is probably why nobody hit it. 720 (SD) and 1080 (vertical video) both trigger it.

Decoding 720x480 to P216, chroma gets displaced a little further on every row, and 23552 bytes are written past the end of the UV plane. PA16 has the same bug, but there the stray writes land inside the alpha plane rather than past the allocation, so it corrupts alpha quietly instead of overflowing.

<img width="2184" height="528" alt="vmx_p216_comparison" src="https://github.com/user-attachments/assets/ea803e1e-6c49-4de2-aec4-abdf95875a89" />

Fix is to use `pDst` in the loop and advance that, which is what `VMX_PlanarToUYVY` directly above already does. Same change in both the x86 and ARM copies.

Feels like the decode-side counterpart to f73569e, which fixed the encode path for unaligned strides.

Testing:

- Swept every even width from 16 to 640, plus the usual broadcast sizes, progressive and interlaced, P216 and PA16. Every case with width % 32 != 0 failed before the change. All of them pass after.
- Compared the packer output against the decoder's internal planes bit for bit rather than eyeballing frames, so there's no compression tolerance hiding anything.
- ASAN flags the overflow before and is clean after.
- Widths that were already fine give byte-identical output before and after, and the other decode entry points (UYVY, UYVA, YUY2, BGRA, BGRX, all the previews) are unchanged.

Perf: nothing measurable at aligned widths, and the compiler actually emits a few fewer instructions since it no longer has to keep two pointers moving. At unaligned widths, the function is ~6% slower in isolation at 1080 wide, because it now actually populates the scratch buffer instead of skipping that work. At whole-frame level that's inside the run-to-run noise.
