### PR TITLE
Reset AC streams when loading a preview only frame

### DIFF
--- a/src/vmxcodec.cpp
+++ b/src/vmxcodec.cpp
@@ -490,6 +490,47 @@ inline void VMX_ConfigureInterlaced(VMX_INSTANCE* instance, int interlaced) {
 	}
 }
 
+//Append the byte-aligned zero-run code emitted by EncodeZeros for an all-zero plane.
+static int VMX_AppendZeroRun(BYTE* dst, uint32_t numZeros)
+{
+	if (!numZeros) return 0;
+
+	int valueBits = 0;
+	for (uint32_t value = numZeros; value; value >>= 1)
+	{
+		valueBits++;
+	}
+
+	const int codeBits = valueBits * 2;
+	const int paddedBits = (codeBits + 7) & ~7;
+	buffer_t code = (1ULL << (codeBits - 1)) | numZeros;
+	code <<= paddedBits - codeBits;
+
+	const int bytes = paddedBits >> 3;
+	for (int i = 0; i < bytes; i++)
+	{
+		dst[i] = (BYTE)(code >> ((bytes - i - 1) * 8));
+	}
+	return bytes;
+}
+
+//Builds the AC stream for a slice in which every plane is entirely zero.
+//One run per plane, each byte aligned, because the decoder flushes to a byte boundary between planes.
+static int VMX_CreateEmptyACStream(VMX_INSTANCE* instance, BYTE* dst)
+{
+	int len = 0;
+	for (int i = 0; i < VMX_MAX_PLANES; i++)
+	{
+		//The AC entropy stream contains one term per sample in each 8x8 block.
+		const uint32_t numTerms = (uint32_t)instance->Planes[i].Stride * VMX_SLICE_HEIGHT;
+		len += VMX_AppendZeroRun(dst + len, numTerms);
+	}
+
+	//The bit reader loads buffer_t at a time and may read beyond the encoded bits.
+	memset(dst + len, 0xFF, sizeof(buffer_t));
+	return len + sizeof(buffer_t);
+}
+
 VMX_API VMX_ERR VMX_LoadFrom(VMX_INSTANCE* instance, BYTE* data, int dataLen)
 {
 	if (!instance) return VMX_ERR_INVALID_INSTANCE;
@@ -547,6 +588,19 @@ VMX_API VMX_ERR VMX_LoadFrom(VMX_INSTANCE* instance, BYTE* data, int dataLen)
 					memcpy(d.Stream, b, len);
 					b += len;
 					instance->Slices[i]->AC.StreamLength = len;
+				}
+			}
+			else
+			{
+				//A preview only image has no AC section.
+				//Install a compact canonical all-zero AC stream
+				//so a full decode cannot consume a previous frame's AC.
+				BYTE emptyAC[(VMX_MAX_PLANES + 1) * sizeof(buffer_t)];
+				const int emptyACLen = VMX_CreateEmptyACStream(instance, emptyAC);
+				for (int i = 0; i < instance->SliceCount; i++)
+				{
+					memcpy(instance->Slices[i]->AC.Stream, emptyAC, emptyACLen);
+					instance->Slices[i]->AC.StreamLength = 0;
 				}
 			}
 			//instance->Format = (VMX_FORMAT)format;


### PR DESCRIPTION
Continuing on from the P216 fix, I've been running the decoder under ASAN and feeding it malformed and truncated packets to see what falls out. That turned up a few unrelated issues. I'm splitting them into separate PRs so each stays small and easy to review rather than dropping one big change on you. Sorry in advance for the run of them.

One of those cases wasn't malformed at all. It was a valid preview-only packet.

`VMX_GetEncodedPreviewLength` returns the size of the valid DC-only prefix of a packet. When a packet ends at that point, `VMX_LoadFrom` skips the AC loop and leaves the buffers with whatever the previous frame wrote there.

If the caller then performs a full decode with `VMX_DecodeUYVY`, `VMX_DecodeBGRA`, or another full-resolution decoder, the new frame's DC coefficients are combined with the previous frame's AC coefficients.

The result is the previous picture's detail painted over the new pictures colors:

<img width="1292" height="480" alt="vmx_stale_ac" src="https://github.com/user-attachments/assets/31d9b367-696b-4d1c-8683-62904e3a9a70" />

Both panels are the same preview-only packet for frame 2, decoded at full resolution. On the left, on the current master, the previous frame was a checkerboard containing a large circle, and both remain clearly visible. On the right, after this change, the image is softer than a full decode, which is what a DC-only packet should produce, but nothing from the previous frame remains.

### How this can happen in practice

A sender may trim a frame to its preview prefix under bandwidth pressure while the receiver continues rendering at full resolution. There is no API for the receiver to ask whether the loaded packet contained AC data, so it cannot know that it should switch to one of the preview decoders.

The resulting ghosting only appears on preview-only frames and can easily look like an ordinary network artifact.

The same problem occurs if an instance encodes a frame and then loads a preview packet, because encoding fills the same AC buffers.

### The fix

When loading a preview-only packet, this change installs a compact canonical all-zero AC stream in each slice. It contains one byte-aligned zero run per plane using the same representation emitted by `EncodeZeros`. The decoder can then reconstruct a proper DC-only image without consuming stale coefficients.

I initially tried restoring the AC buffers by clearing them to their original `0xFF` state. At 1080p that writes roughly 8 MB per preview packet and more than doubled the cost of the preview-loading path.

The canonical stream requires only a few dozen bytes per slice. It does not require any new allocations, persistent state, public structure changes, or changes to the SIMD decoders.

### Performance

The only measurable work occurs when loading a preview packet:

- A steady preview stream at 1080p remains approximately 120 us.
- Full load and decode was 0.3% slower, within the +/-0.4% same-binary noise floor.
- Alternating full and preview packets went from 13.1 us to 14.5 us at 1080p and remained within the measured noise at 4K.
- The encode path is unchanged.

### Testing

- Loaded a detailed frame followed by a nearly flat preview-only frame, then compared the full decode against a pristine decoder byte for byte. All 84 full-decode combinations failed before this change and pass afterward.
- Verified the four preview decoders remain unchanged. They only consume the DC streams.
- Encoded a frame, loaded a preview packet, and then performed a full decode. All 84 combinations failed before and passed afterward.
- Tested every even width from 16 through 1024, plus the usual production resolutions, for 517 configurations in total. This exercises the stride-derived zero-run lengths.
- Confirmed 264 ordinary full-packet decodes are byte-identical to master.
- Confirmed a full packet following a larger full packet does not consume the stale tail of a slice buffer, so this fix only needs to cover preview-only packets.
- Completed a clean ASAN pass with identical results across repeated runs.
- Confirmed both macOS build recipes compile.

I also ran the complete suite against the x86 build with the 256-bit decode path active (`instance->avx2 = 1`). `vmxcodec_avx2.cpp` contains its own entropy decoder, so this verifies more than just a different IDCT implementation. It passed the same 132/132 and 84/84 checks.

That run was under emulation rather than on native x86 hardware. It used an emulated linux/amd64 container, which, unlike Rosetta for some reason, **does** expose AVX2 and BMI2 (QEMU FTW!). The emulated CPU does not advertise `abm`, so I confirmed `lzcnt` and `tzcnt` return correct values before trusting the results. The width sweep also covers both x86 dispatch paths because the AVX2 path disables itself when the UV-plane width is not divisible by 16. I will be testing more on Windows X64 hardware today to confirm my findings in a non-emulated environment. If anything comes up, I will post it as a follow-up to this PR.