### PR TITLE
Note why the AVX2 path still requires BMI2

### DIFF
--- a/src/vmxcodec.cpp
+++ b/src/vmxcodec.cpp
@@ -230,9 +230,9 @@ VMX_API VMX_INSTANCE* VMX_Create(VMX_SIZE dimensions, VMX_PROFILE profile, VMX_C
 
 #if defined(X64)
 	//Require both AVX2 and BMI2 for the 256-bit path.
-	//That path only actually uses BMI1 (BEXTR in the entropy decoder, TZCNT when
-	//scanning AC runs). BMI2 is still checked because AVX2 and BMI2 arrived together
-	//on Haswell, which is the intended baseline; anything thinner stays on SSE.
+	//That path only actually uses BMI1 + LZCNT (BEXTR in the entropy decoder, TZCNT when
+	//scanning AC runs). 
+	//Checking for BMI2 is simpler than an extra check for LZCNT, since hardly any CPUs are still in use that have BMI1, AVX2 and LZCNT without BMI2 anyway.
 	#if defined(__GNUC__)
 		if (__builtin_cpu_supports("avx2")) {
 			instance->avx2 = 1;

--- a/src/vmxcodec.cpp
+++ b/src/vmxcodec.cpp
@@ -229,6 +229,10 @@ VMX_API VMX_INSTANCE* VMX_Create(VMX_SIZE dimensions, VMX_PROFILE profile, VMX_C
 	instance->avx2 = 0;
 
 #if defined(X64)
+	//Require both AVX2 and BMI2 for the 256-bit path.
+	//That path only actually uses BMI1 (BEXTR in the entropy decoder, TZCNT when
+	//scanning AC runs). BMI2 is still checked because AVX2 and BMI2 arrived together
+	//on Haswell, which is the intended baseline; anything thinner stays on SSE.
 	#if defined(__GNUC__)
 		if (__builtin_cpu_supports("avx2")) {
 			instance->avx2 = 1;


### PR DESCRIPTION
Hi there. Thank you for developing and maintaining awesome codec with vMix!
I made a PR that adds few comments on BMI gate.

The AVX2 encode/decode path only uses BMI1 instructions (BEXTR in the entropy
decoder, TZCNT when walking AC runs). The runtime gate still requires BMI2.

AVX2 and BMI2 landed together on Haswell, which is the
baseline this path is meant for, so the check stays as a generation gate rather
than being relaxed to BMI1 alone. (I assume AMD's piledriver and Steamroller are not supported on OMT/VMX)
CPUs that do not advertise BMI2 keep using the SSE path.
