### PR TITLE
Make vmxcodec.h compatible with C11

### DIFF
--- a/src/vmxcodec.cpp
+++ b/src/vmxcodec.cpp
@@ -24,6 +24,7 @@
 */
 #include "pch.h"
 #include "vmxcodec.h"
+#include "thread_tasks.h"
 #include <thread>
 #include <chrono>
 #include <iostream>
@@ -564,6 +565,7 @@ VMX_API VMX_ERR VMX_LoadFrom(VMX_INSTANCE* instance, BYTE* data, int dataLen)
 	return VMX_ERR_OK;
 }
 
+extern "C" {
 VMX_API void VMX_DecodePlanePreview(VMX_INSTANCE* instance, VMX_PLANE* pPlane, VMX_SLICE_SET* s)
 {
 	VMX_DecodePlanePreviewInternal(instance, pPlane, s);
@@ -577,6 +579,7 @@ VMX_API void VMX_DecodePlane(VMX_INSTANCE* instance, VMX_PLANE* pPlane, VMX_SLIC
 VMX_API void VMX_DecodePlane16(VMX_INSTANCE* instance, VMX_PLANE* pPlane, VMX_SLICE_SET* s)
 {
 	VMX_DecodePlaneInternal16(instance, pPlane, s);
+}
 }
 
 void VMX_DecodeSlices(VMX_INSTANCE* instance, int startIndex, int count)

--- a/src/vmxcodec.h
+++ b/src/vmxcodec.h
@@ -566,6 +566,3 @@ VMX_API int VMX_Test(VMX_INSTANCE* instance, short* src, short* dst);
 }
 #endif
 
-//Private functions
-void VMX_ResetData(VMX_SLICE_DATA* s);
-void VMX_ResetStream(VMX_INSTANCE* instance);

--- a/src/vmxcodec.h
+++ b/src/vmxcodec.h
@@ -24,13 +24,17 @@
 */
 
 #pragma once
-#include <cstdint>
-#include <cstring>
-#include "thread_tasks.h"
+
+#include <stdalign.h>
+#include <stdint.h>
+#include <string.h>
+
+typedef struct ThreadTasks ThreadTasks;
+
 #ifdef _MSC_VER
 #define VMX_API __declspec(dllexport)
 #else
-#define VMX_API extern "C" __attribute__((visibility("default")))
+#define VMX_API __attribute__((visibility("default")))
 #endif
 #if defined(_M_ARM64) | defined(__arm64) | defined(__aarch64__)
 #define ARM64
@@ -40,9 +44,11 @@
 #define AVX2 //Include AVX2 in all Intel builds as these functions will be dynamically called only if instruction set available.
 #endif
 
-const int VMX_SLICE_HEIGHT = 16;
-const int VMX_QUALITY_COUNT = 25;
-const int VMX_MAX_PLANES = 4;
+enum {
+	VMX_SLICE_HEIGHT = 16,
+	VMX_QUALITY_COUNT = 25,
+	VMX_MAX_PLANES = 4
+};
 
 typedef unsigned long long buffer_t;
 typedef unsigned char       BYTE;
@@ -107,7 +113,7 @@ typedef enum {
 	VMX_IMAGE_PA16,
 } VMX_IMAGE_FORMAT;
 
-struct VMX_SLICE_DATA
+typedef struct VMX_SLICE_DATA
 {
 	unsigned char* Stream;
 	unsigned char* StreamPos;
@@ -118,9 +124,9 @@ struct VMX_SLICE_DATA
 	buffer_t Temp;
 	buffer_t TempRead;
 	VMX_SIZE Size[3];
-};
+} VMX_SLICE_DATA;
 
-struct VMX_SLICE_SET
+typedef struct VMX_SLICE_SET
 {
 	VMX_SLICE_DATA DC;
 	VMX_SLICE_DATA AC;
@@ -129,21 +135,21 @@ struct VMX_SLICE_SET
 	VMX_SIZE PixelSize; //Size in pixels of the slice, for copying from source image data. Due to alignment last slice will be only 8 pixels height for 1080 for example.
 	VMX_SIZE PixelSizeInterlaced; //Same as above but for second field alignment adjustment at the mid point.
 	int LowerField; //=1 when this is a lower field slice
-	__declspec(align(64)) short TempBlock[128];
-	__declspec(align(64)) short TempBlock2[128];
-	__declspec(align(64)) short TempBlock3[128];
-};
+	alignas(64) short TempBlock[128];
+	alignas(64) short TempBlock2[128];
+	alignas(64) short TempBlock3[128];
+} VMX_SLICE_SET;
 
-struct VMX_PLANE
+typedef struct VMX_PLANE
 {
 	int Index;
 	VMX_SIZE Size;
 	int Stride; //Double this when dealing with 16bit data
 	BYTE* Data;
 	BYTE* DataLowerPreview;
-};
+} VMX_PLANE;
 
-struct VMX_INSTANCE
+typedef struct VMX_INSTANCE
 {
 	int avx2;
 	VMX_FORMAT Format;
@@ -188,10 +194,16 @@ struct VMX_INSTANCE
 	int ImageStrideA;
 
 	VMX_IMAGE_FORMAT ImageFormat;
+} VMX_INSTANCE;
+
+enum {
+	VMX_DECODE_MATRIX_COUNT = 64,
+	VMX_ENCODE_MATRIX_COUNT = 192
 };
 
-const int VMX_DECODE_MATRIX_COUNT = 64;
-const int VMX_ENCODE_MATRIX_COUNT = 192;
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 //Public exports
 
@@ -549,8 +561,11 @@ VMX_API int VMX_GetThreads(VMX_INSTANCE* instance);
 VMX_API void VMX_SetThreads(VMX_INSTANCE* instance, int numThreads);
 
 VMX_API int VMX_Test(VMX_INSTANCE* instance, short* src, short* dst);
+
+#ifdef __cplusplus
+}
+#endif
+
 //Private functions
 void VMX_ResetData(VMX_SLICE_DATA* s);
 void VMX_ResetStream(VMX_INSTANCE* instance);
-
-

--- a/src/vmxcodec_common.h
+++ b/src/vmxcodec_common.h
@@ -25,6 +25,7 @@
 #pragma once
 #include "vmxcodec.h"
 #include <math.h>
+#include <stdlib.h>
 
 #define VMX_ALIGNMENT (64)
 #define VMX_BITSSIZE (64)


### PR DESCRIPTION
The documentation says libvmx is a C/C++ library, but when I tried to use it from a C project, I found that `vmxcodec.h` could only be compiled as C++. It includes C++ headers and threading code, uses C++ linkage syntax directly, and has a few declarations that are not valid C.

This makes the header usable from C11 while keeping the existing C++ interface intact. The threading implementation is now included only where it is used, and the shared declarations use syntax supported by both C and C++.

There are no changes to function signatures, public structure layouts, codec behavior, or performance.

I tested the header in strict C11 and C++17 modes and rebuilt both the ARM64 and x86-64 libraries.

QUESTION: vmxcodec.h still ends with `VMX_ResetData` and `VMX_ResetStream` under a "//Private functions" comment. I left those alone to keep this PR focused, but should those declarations be moved out of the public header (and into something like vmxcodec_common.h) in a follow-up?